### PR TITLE
Fix chunk obstacle prefab references

### DIFF
--- a/Assets/Chunks/ChunkData_Easy_01.asset
+++ b/Assets/Chunks/ChunkData_Easy_01.asset
@@ -15,6 +15,6 @@ MonoBehaviour:
   prefab: {fileID: 6854345420925121602, guid: f4e8dda95a65ef842a9210897cdc675e, type: 3}
   difficulty: 0
   weight: 5
-  leftObstacle: {fileID: 0}
-  centerObstacle: {fileID: 0}
-  rightObstacle: {fileID: 0}
+  leftObstacle: {fileID: 5222080706443180929, guid: 53bc1388c85ea0e4aa05c215d6efe459, type: 3}
+  centerObstacle: {fileID: 5222080706443180929, guid: 53bc1388c85ea0e4aa05c215d6efe459, type: 3}
+  rightObstacle: {fileID: 5222080706443180929, guid: 53bc1388c85ea0e4aa05c215d6efe459, type: 3}

--- a/Assets/Prefabs/Chunk_Easy_01.prefab
+++ b/Assets/Prefabs/Chunk_Easy_01.prefab
@@ -66,7 +66,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a67f749c4dc53b0439471e183f3b0642, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  side: 0
+  side: 1
 --- !u!1 &4539175055587903911
 GameObject:
   m_ObjectHideFlags: 0
@@ -267,7 +267,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a67f749c4dc53b0439471e183f3b0642, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  side: 0
+  side: 2
 --- !u!1 &9059307154717041940
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
- assign the `Obstacle.prefab` as the left/center/right obstacle on `ChunkData_Easy_01`
- set the center and right spawn trigger sides correctly in `Chunk_Easy_01`

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68485d7421508320a3bc05794fdc3933