### PR TITLE
Fix spawn trigger heights

### DIFF
--- a/Assets/Prefabs/Chunk_Easy_01.prefab
+++ b/Assets/Prefabs/Chunk_Easy_01.prefab
@@ -27,7 +27,7 @@ Transform:
   m_GameObject: {fileID: 2300595951606648304}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 10, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -94,7 +94,7 @@ Transform:
   m_GameObject: {fileID: 4539175055587903911}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3, y: 10, z: 0}
+  m_LocalPosition: {x: -3, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -228,7 +228,7 @@ Transform:
   m_GameObject: {fileID: 8905914233345331998}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3, y: 10, z: 0}
+  m_LocalPosition: {x: 3, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []


### PR DESCRIPTION
## Summary
- update spawn trigger positions in `Chunk_Easy_01` so Y is 0 instead of 10

## Testing
- `grep -n m_LocalPosition Assets/Prefabs/Chunk_Easy_01.prefab | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6848817438148320a391210971568cb3