### PR TITLE
Implement pooled object retrieval for obstacles

### DIFF
--- a/Assets/Scripts/PoolManager.cs
+++ b/Assets/Scripts/PoolManager.cs
@@ -36,6 +36,29 @@ public class PoolManager : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Return an inactive instance for the given prefab, creating one if needed.
+    /// </summary>
+    public GameObject GetPooledObject(GameObject prefab)
+    {
+        if (!pools.ContainsKey(prefab))
+            pools[prefab] = new Queue<GameObject>();
+
+        GameObject instance;
+        if (pools[prefab].Count > 0)
+        {
+            instance = pools[prefab].Dequeue();
+        }
+        else
+        {
+            instance = Instantiate(prefab);
+            instance.SetActive(false);
+            var po = instance.AddComponent<PooledObject>();
+            po.OriginalPrefab = prefab;
+        }
+        return instance;
+    }
+
     /// <summary>Get an instance (reuse or new) at pos/rot.</summary>
     public GameObject Spawn(GameObject prefab, Vector3 pos, Quaternion rot)
     {


### PR DESCRIPTION
## Summary
- extend `PoolManager` with `GetPooledObject` for retrieving inactive instances
- rework `ObstacleSpawnTrigger2D` to use the new pooling API
- add safety checks and fade-in behaviour for spawned obstacles

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849013e150083209a269a9131f74733