### PR TITLE
Fix pooled obstacle initialization order

### DIFF
--- a/Assets/Scripts/ObstacleSpawnTrigger2D.cs
+++ b/Assets/Scripts/ObstacleSpawnTrigger2D.cs
@@ -69,9 +69,9 @@ public class ObstacleSpawnTrigger2D : MonoBehaviour
             return;
 
         var go = poolManager.GetPooledObject(obstaclePrefab);
-        go.SetActive(true);
         go.transform.SetParent(spawnParent, false);
         go.transform.position = transform.position;
+        go.SetActive(true);
 
         StartCoroutine(FadeInCoroutine(go.GetComponent<SpriteRenderer>(), 0.3f));
     }


### PR DESCRIPTION
## Summary
- ensure pooled obstacle is configured before enabling it

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490905d85c83209798e47912e9646f